### PR TITLE
Change isPending of initialStateRobots to false in reducers.test.js

### DIFF
--- a/src/reducers.test.js
+++ b/src/reducers.test.js
@@ -29,14 +29,14 @@ describe('searchRobots reducer', () => {
 
 const initialStateRobots = {
   robots: [],
-  isPending: true
+  isPending: false
 }
 describe('requestRobots reducer', () => {
   it('should return the initial state', () => {
     expect(reducers.requestRobots(undefined, {})).toEqual(
       {
         robots: [],
-        isPending: true
+        isPending: false
       }
     )
   })
@@ -85,7 +85,7 @@ describe('requestRobots reducer', () => {
       {
         error: 'NOOO',
         robots: [],
-        isPending: true
+        isPending: false
       }
     )
   })


### PR DESCRIPTION
isPending property should be set to false in the initial state as well as in the REQUEST_ROBOTS_FAILED test, shouldn't it?