### PR TITLE
fix: remove mockProps and wrapper from fileters Robots

### DIFF
--- a/src/components/MainPage.test.js
+++ b/src/components/MainPage.test.js
@@ -20,13 +20,6 @@ it('renders without crashing', () => {
 });
 
 it('fileters Robots', () => {
-  const mockProps = {
-    onRequestRobots: jest.fn(),
-    robots: [],
-    searchField: 'a',
-    isPending: false
-  }
-  wrapper = shallow(<MainPage {...mockProps}/>)
   expect(wrapper.instance().filterRobots()).toEqual([]);
 });
 


### PR DESCRIPTION
Remove mockProps and wrapper from 'fileters Robots' in the MainPage.test.js

These values are not needed because are already defined in the beforeEach():

```
beforeEach(() => {
  const mockProps = {
    onRequestRobots: jest.fn(),
    robots: [],
    searchField: '',
    isPending: false
  }
  wrapper = shallow(<MainPage {...mockProps}/>)
 })
```